### PR TITLE
Suggesting changes to PineBlasterV2 for the Wi-Fire board

### DIFF
--- a/PineBlasterV2.ino
+++ b/PineBlasterV2.ino
@@ -190,7 +190,7 @@ void run_clock(int runcache){
   //    * Does the commented out code achieve the sam ething in less instructions?
   // once the wait is complete, detach the interrupt so future triggers do not 
   // slow down the execution
-  //detachInterrupt(); 
+  //detachInterrupt(0); 
 //  IEC0bits.INT0IE  = 0;  
 //  setIntPriority(0, 0, 0); // this will disable the interrupt
 //  /* Compute the address of the interrupt priority control register used

--- a/PineBlasterV2.ino
+++ b/PineBlasterV2.ino
@@ -30,6 +30,7 @@ const unsigned int max_instructions = 64350;
 const unsigned int max_instructions = 15050;
 #endif
 int autostart;
+volatile int reset_on_serial = 0;
 unsigned int instructions[2*max_instructions + 6]; // 3 extra instructions (2 32-bit ints per instruction). two initial blank instructions (for the caching hack) and 1 for stop instruction at end
 volatile unsigned int * resume_address = instructions;
 
@@ -42,6 +43,20 @@ volatile int hold_final = 1;
 #define MIN_PULSE 6 //TODO: Fix this for bitblaster, define for pineblaster
 
 #define DEBUG 0
+void __attribute__((naked, at_vector(24), nomips16)) IntSer0Handler(void){
+  // This interrupt is called whenever serial communication arrives. We
+  // intercept it and decide whether to treat it as ordinary serial communication,
+  // or as an abort signal (for when the sequence is running). In the case of an abort signal,
+  // we can reset the CPU.
+  // Load in the address of reset_on_serial:
+  asm volatile ("la $k0, reset_on_serial\n\t");
+  // load in the value of reset_on_serial:
+  asm volatile ("lw $k0, 0($k0)\n\t");
+  // if it's zero, do the usual serial handler:
+  asm volatile ("beq $k0, $zero, IntSer0Handler\n\t");
+  // Otherwise, do a reset! (jump to the below function)
+  asm volatile ("j reset\n\t");
+}
 
 void __attribute__((naked, nomips16)) Reset(void){
   // does a software reset of the CPU:
@@ -74,7 +89,8 @@ void start_clock(){
     Serial.println("DEBUG: attaching serial interrupt");
   #endif
   // Any serial communication will now reset the CPU:
-  Serial.attachInterrupt(serialInterruptDuringRun);
+  //Serial.attachInterrupt(serialInterruptDuringRun);
+  reset_on_serial = 1;
   
   int incomplete = 1;
   int runcache = 1;
@@ -174,7 +190,7 @@ void run_clock(int runcache){
   //    * Does the commented out code achieve the sam ething in less instructions?
   // once the wait is complete, detach the interrupt so future triggers do not 
   // slow down the execution
-  detachInterrupt(0); 
+  //detachInterrupt(); 
 //  IEC0bits.INT0IE  = 0;  
 //  setIntPriority(0, 0, 0); // this will disable the interrupt
 //  /* Compute the address of the interrupt priority control register used
@@ -503,7 +519,7 @@ void setup(){
   digitalWrite(PIN_LED2,LOW);
 
   // Announce we are ready!
-  Serial.println("ready");
+  //Serial.println("ready");
 }
 
 int set_bits(int i, uint32_t val, uint32_t ts)


### PR DESCRIPTION
I tested V2 of PineBlaster to flash the Digilent Wi-Fire board, and it does not work as a pseudoclock  for labscript. Since I'm not expert on this, by trial and error, and comparing with the first version I found what needs to be changed. 

This was tested with Arduino IDE v1.6.7, chipKIT core version 1.3.1, and the Wi-Fire board.
Three changes will be necessary: 

1)
// Announce we are ready!
//Serial.println("ready");
This message is expected on BitBlaster but not on PineBlaster, so one of them needs to be modified to have the same .ino file working for both. Currently, if  this line is removed it will work for Pineblaster but not for bitblaster. Maybe Pineblaster.py (in labscript devices) will need to be modified because Max32 and Wi-Fire have different specifications. 

2)
In void start_clock(), it seems "Serial.attachInterrupt(serialInterruptDuringRun)" does a full reset when the experimental sequence starts running in Blacs, LD1 flashes like when we reinicialize the device. In this case, Pineblaster.py, 
 
def start_run(self):
    # Start in software:
    self.pineblaster.write(b'start\r\n')

breaks with the message " PineBlaster said ''o'', expected 'ok' ".

To make this part working I had to replace it by "reset_on_serial = 1 (and it's definition) imported from the first version of PineBlaster. 


3)
In these lines
  // once the wait is complete, detach the interrupt so future triggers do not 
  // slow down the execution
  detachInterrupt(0); 
If we keep "detachInterrupt(0)" pineblaster.py does not receive "done", therefore I commented out this line.